### PR TITLE
Add VS Code devcontainer for MapAnything

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+
+# CUDA \u226512.8 is required for building custom ops for recent GPUs (e.g., Blackwell sm_100)
+FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
+# Ensure any CUDA extensions compile for a wide range of NVIDIA GPUs
+ENV TORCH_CUDA_ARCH_LIST="80;86;89;90;100"
+
+# Base OS dependencies
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    python3 python3-pip python3-venv python3-dev \
+    git curl wget ca-certificates build-essential \
+    libgl1-mesa-glx libxkbcommon-x11-0 x11-apps ffmpeg \
+    ninja-build cmake pkg-config openssh-client \
+    libssl-dev libffi-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# Make python point to python3
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
+# Fresh pip
+RUN python -m pip install --upgrade pip
+
+# Helpful utilities
+RUN pip install -U "huggingface_hub[hf_xet]"
+
+# Prefer SSH for GitHub remotes to leverage mounted host SSH keys
+RUN git config --system url."ssh://git@github.com/".insteadOf https://github.com/
+
+# Pre-populate GitHub host key to avoid prompts in fresh containers
+RUN mkdir -p /etc/ssh \
+ && ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> /etc/ssh/ssh_known_hosts 2>/dev/null || true
+
+# Avoid git safety prompts when working in bind-mounted workspace
+RUN git config --global --add safe.directory /workspace
+
+WORKDIR /workspace
+EXPOSE 7860
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+{
+  "name": "MapAnything Dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+
+  "runArgs": [
+    "--gpus",
+    "all",
+    "--shm-size=64g", // increase shared memory for heavy training/inference workloads
+    "--ipc=host"      // share host IPC to avoid NCCL shared-memory limits
+  ],
+
+  "mounts": [
+    // Uncomment and edit the paths below to surface local datasets or secrets inside the container.
+    // "source=/home/nfs/datasets/internal,target=/data,type=bind,consistency=cached,readonly=false",
+    // "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,readonly",
+    // "source=${localEnv:HOME}/.codex,target=/root/.codex,type=bind"
+  ],
+
+  "containerEnv": {
+    "CODEX_HOME": "/root/.codex",
+    "TORCH_CUDA_ARCH_LIST": "80;86;89;90;100"
+  },
+
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
+  "workspaceFolder": "/workspace",
+
+  "forwardPorts": [7860],
+
+  "postCreateCommand": "/bin/bash .devcontainer/post-create.sh",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-toolsai.jupyter"
+      ]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure the workspace root is used as the working directory
+cd /workspace
+
+export DEBIAN_FRONTEND=noninteractive
+
+APT_PACKAGES=(
+  libavcodec-dev
+  libavdevice-dev
+  libavformat-dev
+  libavfilter-dev
+  libswscale-dev
+  libswresample-dev
+  libavutil-dev
+)
+
+# Install multimedia dependencies required by several demos and video utilities
+apt-get update
+apt-get install -y --no-install-recommends "${APT_PACKAGES[@]}"
+rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip tooling inside the container
+python -m pip install --upgrade pip setuptools wheel
+
+# Install PyTorch (CUDA 12.8 build) matching the base image toolchain
+PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cu128"
+python -m pip install --upgrade --no-cache-dir \
+  torch torchvision torchaudio --index-url "${PYTORCH_INDEX_URL}"
+
+# Install MapAnything with all optional extras for a feature-complete developer environment
+python -m pip install --no-cache-dir -e .[all]
+
+# Set up linting hooks
+if command -v pre-commit >/dev/null 2>&1; then
+  pre-commit install --install-hooks || pre-commit install
+fi
+
+# Surface the repository to the Python path for interactive shells spawned outside pip
+PYTHONPATH_LINE='export PYTHONPATH="/workspace:${PYTHONPATH:-}"'
+if ! grep -Fxq "${PYTHONPATH_LINE}" /root/.bashrc 2>/dev/null; then
+  echo "${PYTHONPATH_LINE}" >> /root/.bashrc
+fi
+
+cat <<'INFO'
+=====================================================
+Dev container post-create steps completed successfully
+- CUDA dev image ready for custom operator builds
+- PyTorch + MapAnything (with extras) installed
+- pre-commit hooks configured
+=====================================================
+INFO


### PR DESCRIPTION
## Summary
- add a GPU-ready VS Code devcontainer definition wired to a CUDA 12.8 base image
- install CUDA-aware build toolchain and helpful git defaults in the custom Dockerfile
- automate PyTorch/cu128, MapAnything extras, and tooling installation via post-create script

## Testing
- bash -n .devcontainer/post-create.sh

------
https://chatgpt.com/codex/tasks/task_e_68cd03f039ec8327accfcb8f4421313e